### PR TITLE
debug bone ids

### DIFF
--- a/cheat/main.cpp
+++ b/cheat/main.cpp
@@ -87,6 +87,7 @@ void RunSoftware() {
 				if (tab == 1) {
 
 					ImGui::Checkbox(XorStr("ESP"), &vars::visuals::enabled);
+					ImGui::Checkbox(XorStr("Debug Bones"), &vars::visuals::players::debug_bones);
 					ImGui::Checkbox(XorStr("Player Box"), &vars::visuals::players::box);
 					ImGui::Checkbox(XorStr("Player Knocked"), &vars::visuals::players::knocked);
 					ImGui::Checkbox(XorStr("Player Name"), &vars::visuals::players::name);

--- a/cheat/modules/visuals/visuals.cpp
+++ b/cheat/modules/visuals/visuals.cpp
@@ -36,6 +36,14 @@ void CVisuals::PlayerESP(uintptr_t entity, uintptr_t localent)
 
 			int iY = 0;
 
+			if (vars::visuals::players::debug_bones)
+			{
+				for (int i = 0; i < 300; i++) // to save runtime only doing 300 which seems to show most if not all bones
+				{
+					Vector3 BonePos = WorldToScreen(entity::GetEntityBonePosition(entity, i, FeetPosition), Width, Height);
+					DrawOutlinedText(m_pFont, std::to_string(i), ImVec2(BonePos.x, BonePos.y), 12, IM_COL32(255, 255, 255, 255), true); // sussy baka code
+				}
+			}
 			if (vars::visuals::players::box)
 			{
 				DrawBox(CenterHitbox.x, FeetHitbox.y, box_width, box_height, IM_COL32(255, 255, 255, 255));

--- a/cheat/sdk/include/vars.h
+++ b/cheat/sdk/include/vars.h
@@ -13,7 +13,7 @@ namespace vars {
 		inline bool enabled = true;
 
 		namespace players {
-			inline bool name = true, knocked = true, health = true, shield = true, distance = true, box = true, glow = true;
+			inline bool name = true, knocked = true, health = true, shield = true, distance = true, box = true, glow = true, debug_bones = false;
 			inline float distancelimit = 500;
 		}
 	}


### PR DESCRIPTION
shows the bone id in a player model... Can be used on the dummy's if you change the caching loop.
This is only useful for debugging purposes.